### PR TITLE
Remove CLAUDE.md from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,3 @@ Icon
 
 # Claude Code
 .claude/
-CLAUDE.md


### PR DESCRIPTION
## Summary
- `CLAUDE.md` is now tracked by git via the Boost commit, making the `.gitignore` entry ineffective and misleading
- Removed `CLAUDE.md` from `.gitignore` while keeping `.claude/` ignored

## Test plan
- [ ] Verify `.gitignore` no longer lists `CLAUDE.md`
- [ ] Verify `.claude/` remains gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)