### PR TITLE
Change migrate flag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
             "Composer\\Config::disableProcessTimeout",
             "./vendor/bin/sail up -d",
             "./vendor/bin/sail yarn",
-            "./vendor/bin/sail artisan migrate -y",
+            "./vendor/bin/sail artisan migrate -f",
             "./vendor/bin/sail yarn run build:ssr",
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"./vendor/bin/sail artisan horizon:listen --poll --tries=1\" \"./vendor/bin/sail artisan pail --timeout=0\" \"./vendor/bin/sail artisan inertia:start-ssr\" --names=server,horizon,logs,ssr --kill-others"
         ],


### PR DESCRIPTION
This pull request makes a minor update to the migration command in the `composer.json` file, changing the migration flag from `-y` to `-f` for the Sail Artisan migrate script. This enforces a "force" mode for running migrations in automated setups.

- Changed the Sail Artisan migrate command in `composer.json` from using the `-y` (yes) flag to the `-f` (force) flag, ensuring migrations run without interactive prompts.