### PR TITLE
Remove 'Settings' from app sidebar navigation

### DIFF
--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -49,12 +49,7 @@ const mainNavItems: NavItem[] = [
         title: 'Maintenance',
         href: maintenance.index(),
         icon: Wrench,
-    },
-    {
-        title: 'Settings',
-        href: profile.edit(),
-        icon: Settings,
-    },
+    }
 ];
 
 const footerNavItems: NavItem[] = [


### PR DESCRIPTION
Removed the 'Settings' item from the sidebar navigation.